### PR TITLE
Nfft updates

### DIFF
--- a/doc/source/math/trafos/fourier_transform.rst
+++ b/doc/source/math/trafos/fourier_transform.rst
@@ -98,7 +98,7 @@ Discretization of the Fourier transform operator means evaluating the Fourier in
     :label: discr_function
 
 with coefficients :math:`\bar f = (f_0, \dots, f_{n-1}) \in \mathbb{C}^n` and functions
-:math:`\phi_0, \dots, \phi_{n-1}`. This approach follows from the way , but can be
+:math:`\phi_0, \dots, \phi_{n-1}`.
 We consider in particular functions generated from a single
 kernel :math:`\phi` via
 
@@ -159,7 +159,7 @@ There is a certain degree of freedom in the choice of the most negative frequenc
 Usually one wants to center the Fourier space grid around zero since most information is typically
 concentrated there. Point-symmetric grids are the standard choice, however sometimes one explicitly
 wants to include (for even :math:`n`) or exclude (for odd :math:`n`) the zero frequency from the
-grid, which is achieved by shifting the frequency :math:`xi_0` by :math:`-\sigma/2`. This results in
+grid, which is achieved by shifting the frequency :math:`\xi_0` by :math:`-\sigma/2`. This results in
 two possible choices
 
 .. math::

--- a/odl/trafos/backends/pynfft_bindings.py
+++ b/odl/trafos/backends/pynfft_bindings.py
@@ -9,13 +9,96 @@
 """Bindings to the ``pynfft`` back-end for non-uniform Fourier transforms.
 
 The `pynfft <https://pythonhosted.org/pyNFFT/>`_  package is a Python
-wrapper around the well-known `NFFT <https://www-user.tu-chemnitz.de/~potts/nfft/>`_
-library for non-uniform fast Fourier transforms.
+wrapper around the well-known
+ `NFFT <https://www-user.tu-chemnitz.de/~potts/nfft/>`_ library for
+non-uniform fast Fourier transforms.
 """
+
+import numpy as np
+
 try:
     import pynfft
     PYNFFT_AVAILABLE = True
 except ImportError:
     PYNFFT_AVAILABLE = False
 
-__all__ = ('PYNFFT_AVAILABLE', )
+__all__ = ('PYNFFT_AVAILABLE', 'normalize_samples')
+
+
+def normalize_samples(samples, grid_spacing, out=None):
+    r"""Normalize samples to [-0.5; 0.5[.
+
+    Parameters
+    ----------
+    samples : array-like
+        Array of unnormalized samples. Its shape is expected to be
+        ``(M, d)``, where ``M`` is the number of samples, and ``d`` the
+        dimension of the space.
+    grid_spacing : positive float or sequence of positive float
+        Step between grid points in the space on which the non-uniform Fourier
+        transform is applied. A sequence must have length ``d``. A single
+        float is interpreted as the same spacing in each dimension.
+    out : numpy.ndarray, optional
+        Array in which the result should be stored. Must have the same shape
+        as ``samples``.
+
+    Returns
+    -------
+    norm_samples : numpy.ndarray
+        Normalized samples. See Notes for details. If ``out`` was given, the
+        returned array is a reference to it.
+
+    Notes
+    -----
+    For a uniformly discretized space with grid spacing
+    :math:`s > 0 \in \mathbb{R}^d`, samples :math:`\xi_k \in \mathbb{R}^d`
+    are normalized to
+
+    .. math::
+        \bar \xi_k = \frac{s \odot \xi_k}{2\pi}.
+
+    Since the reciprocal grid extends from :math:`-\pi s^{-1}` to
+    :math:`\pi s^{-1}`, this transformation normalized the samples to lie
+    between :math:`-0.5` and :math:`0.5`. Due to implementation details,
+    the value :math:`0.5` has to be replaced with :math:`-0.5`, which gives
+    the same result for periodic inputs.
+    """
+    samples = np.array(samples, copy=False, ndmin=2)
+    if samples.ndim != 2:
+        raise ValueError(
+            '`samples` must have 2 dimensions, got array with `ndim={}`'
+            ''.format(samples.ndim)
+        )
+    ndim = samples.shape[1]
+
+    grid_spacing_in = grid_spacing
+    try:
+        iter(grid_spacing)
+    except TypeError:
+        grid_spacing = [float(grid_spacing)] * ndim
+    else:
+        grid_spacing = [float(s) for s in grid_spacing]
+
+    if len(grid_spacing) != ndim:
+        raise ValueError(
+            '`grid_spacing` must have length of `samples.shape[1]`, but '
+            '{} != {}'.format(len(grid_spacing), ndim)
+        )
+
+    if any(s <= 0 for s in grid_spacing):
+        raise ValueError(
+            '`grid_spacing` must be positive, got {}'.format(grid_spacing_in)
+        )
+
+    if out is not None and out.shape != samples.shape:
+        raise ValueError(
+            '`out.shape` must be equal to `samples.shape`, but {} != {}'
+            ''.format(out.shape, samples.shape)
+        )
+
+    grid_spacing = np.array(grid_spacing, dtype=samples.dtype)
+    norm_samples = np.multiply(
+        samples, (grid_spacing[None, :] / 2 * np.pi), out=out
+    )
+    norm_samples[norm_samples == 0.5] = -0.5
+    return norm_samples

--- a/odl/trafos/backends/pynfft_bindings.py
+++ b/odl/trafos/backends/pynfft_bindings.py
@@ -98,7 +98,7 @@ def normalize_samples(samples, grid_spacing, out=None):
 
     grid_spacing = np.array(grid_spacing, dtype=samples.dtype)
     norm_samples = np.multiply(
-        samples, (grid_spacing[None, :] / 2 * np.pi), out=out
+        samples, (grid_spacing[None, :] / (2 * np.pi)), out=out
     )
     norm_samples[norm_samples == 0.5] = -0.5
     return norm_samples

--- a/odl/trafos/non_uniform_fourier.py
+++ b/odl/trafos/non_uniform_fourier.py
@@ -215,11 +215,13 @@ class NonUniformFourierTransform(NonUniformFourierTransformBase):
                     self.samples, self.domain.cell_sides, out=self.samples
                 )
             self.nfft.precompute()
+            self.nfft.x = self.samples
             self._has_run = True
 
         self.nfft.f_hat = np.asarray(x)
         out = self.nfft.trafo()
-        # TODO(kohr-h): normalize to match uniform FT
+        out *= self.domain.cell_volume / (2 * np.pi)
+        # TODO(kohr-h): phase factor needed
         return out
 
     @property
@@ -301,11 +303,13 @@ class NonUniformFourierTransformAdjoint(NonUniformFourierTransformBase):
                     self.samples, self.domain.cell_sides, out=self.samples
                 )
             self.nfft.precompute()
+            self.nfft.x = self.samples
             self._has_run = True
 
         self.nfft.f = np.asarray(x)
         out = self.nfft.adjoint()
-        # TODO(kohr-h): normalize to match uniform FT
+        out *= self.range.cell_volume / (2 * np.pi)
+        # TODO(kohr-h): phase factor needed
         return out
 
 


### PR DESCRIPTION
**Note:** This currently doesn't work correctly on my system, there seems to be an unwanted phase factor. I don't know exactly which one but haven't spent a lot of time investigating.

---

## Suggested changes ##

- Make `normalize_samples` a standalone function.

  The main reason for this is that normalization is useful for advanced users who want to normalize themselves or in another way make sure that things are normalized, to avoid paying the penalty on every invocation. Also makes the inner workings of the whole thing a bit more transparent.
  As a standalone function, of course, more checking has to happen, and the function has to be more liberal with respect to its inputs.

- Normalization should take grid spacing in real space into account, not blindly normalize.

  This is in line with the explanations given in [the Fourier transform documentation](https://odlgroup.github.io/odl/math/trafos/fourier_transform.html), and makes it easier to match the two transforms for the uniform case.

- The range of the NFFT should be a `TensorSpace` without spatial structure.

  This is similar to the wavelet transform that computes coefficients which do not really have a (uniform) spatial structure. Just using `cn(M)` is the simplest and most logical choice IMO.

- The user-facing classes should infer the space of coefficients by default.

  To be more user-friendly, only the domain should be mandatory to specify, and a default range should be inferred based on the number of samples and the `dtype` of the domain. Giving a custom range should be optional.
  This is the same behavior as for the uniform FT.

- Scaling of the transform should be based on grid spacing and shifts.

  This is also analogous to the case of uniform FT and follows the reasoning in the [documentation](https://odlgroup.github.io/odl/math/trafos/fourier_transform.html).

- Advanced arguments should be hidden in `kwargs`.

  This is somewhat debatable, but we tend to put function arguments intended for advanced use into the keyword arguments `**kwargs`. That makes them a bit less obvious, in some sense only for those who read the documentation where they are explained.
  One such case is the `nfft` parameter that I added below. This is mostly for sharing some computation between forward and adjoint transform but could also be used outside of that. For this specific case, the chosen way might not be the best one, but for efficiency I think it's good do use *some* sharing of computations.

